### PR TITLE
removed initial assignments which were causing issues in linting

### DIFF
--- a/axi_i2c_bridge/bench/tst_bench_top.sv
+++ b/axi_i2c_bridge/bench/tst_bench_top.sv
@@ -342,7 +342,16 @@ task read_from_i2c_slave();
 	      end
 	      else blocking_read(read_sr_addr,0,-1);  
      end
-     else  if(state == (initial_state+6)) begin
+     else if(state == (initial_state+6))  blocking_write(write_cr_addr,{8'b00100000});
+     else if(state == (initial_state+7))  blocking_read(read_sr_addr,1,-1);     // read the status register for TIP Flag slave address with write flag
+     else if(state == (initial_state+8))  begin
+	      if((read_data & {8'b00000010}) == 0) begin
+		$display(" Received data from I2C ");
+		state += 1;
+	      end
+	      else blocking_read(read_sr_addr,0,-1);  
+     end
+     else  if(state == (initial_state+9)) begin
 	  //$display(" Data Received After Read ",read_data);
 	  initial_state += 1;
 	  state = initial_state;  

--- a/axlite2wb/rtl/axilrd2wbsp.sv
+++ b/axlite2wb/rtl/axilrd2wbsp.sv
@@ -105,8 +105,8 @@ module	axilrd2wbsp #(
 	reg     [DW-1:0]        captured_read_data ;
 	// o_wb_cyc, o_wb_stb
 	// {{{
-	initial	o_wb_cyc = 1'b0;
-	initial	o_wb_stb = 1'b0;
+	//initial	o_wb_cyc = 1'b0;
+	
 	always @(posedge i_clk)
 	if ((w_reset)||((o_wb_cyc)&&(i_wb_err))||(err_state))
 		o_wb_stb <= 1'b0;
@@ -136,24 +136,23 @@ module	axilrd2wbsp #(
 	// r_stb, r_addr
 	// {{{
 	// Shadow request
-	initial	r_stb = 1'b0;
+	//initial	r_stb = 1'b0;
 	always @(posedge i_clk)
 	begin
-		if ((i_axi_arvalid)&&(o_axi_arready)&&(o_wb_stb)&&(i_wb_stall))
+		if ((w_reset)||(o_wb_cyc)&&(i_wb_err)||(err_state))
+			r_stb <= 1'b0;
+		else if ((i_axi_arvalid)&&(o_axi_arready)&&(o_wb_stb)&&(i_wb_stall))
 		begin
 			r_stb  <= 1'b1;
 			r_addr <= i_axi_araddr;
 		end else if ((!i_wb_stall)||(!o_wb_cyc))
-			r_stb <= 1'b0;
-
-		if ((w_reset)||(o_wb_cyc)&&(i_wb_err)||(err_state))
 			r_stb <= 1'b0;
 	end
 	// }}}
 
 	// wb_pending, wb_outstanding
 	// {{{
-	initial	wb_pending     = 0;
+	//initial	wb_pending     = 0;
 	always @(posedge i_clk)
 	if ((w_reset)||(!o_wb_cyc)||(i_wb_err)||(err_state))
 	begin
@@ -170,7 +169,7 @@ module	axilrd2wbsp #(
 	// }}}
 
 
-	initial	o_axi_arready = 1'b1;
+	//initial	o_axi_arready = 1'b1;
 	always @(posedge i_clk)
 	if (w_reset)
 		o_axi_arready <= 1'b1;
@@ -203,7 +202,7 @@ module	axilrd2wbsp #(
 
 	// o_axi_rresp
 	// {{{
-	initial	o_axi_rresp = 2'b00;
+	//initial	o_axi_rresp = 2'b00;
 	always @(posedge i_clk)
 	if (w_reset)
 		o_axi_rresp <= 0;
@@ -225,7 +224,7 @@ module	axilrd2wbsp #(
 
 	// err_state
 	// {{{
-	initial err_state  = 0;
+	//initial err_state  = 0;
 	always @(posedge i_clk)
 	if (w_reset)
 		err_state <= 0;
@@ -236,7 +235,7 @@ module	axilrd2wbsp #(
 
 	// o_axi_rvalid
 	// {{{
-	initial	o_axi_rvalid = 1'b0;
+	//initial	o_axi_rvalid = 1'b0;
 	always @(posedge i_clk)
 	if (w_reset)
 		o_axi_rvalid <= 0;

--- a/axlite2wb/rtl/axilwr2wbsp.sv
+++ b/axlite2wb/rtl/axilwr2wbsp.sv
@@ -108,8 +108,8 @@ module	axilwr2wbsp #(
 
 	// o_wb_cyc, o_wb_stb
 	// {{{
-	initial	o_wb_cyc = 1'b0;
-	initial	o_wb_stb = 1'b0;
+	//initial	o_wb_cyc = 1'b0;
+	//initial	o_wb_stb = 1'b0;
 	always @(posedge i_clk)
 	if ((w_reset)||((o_wb_cyc)&&(i_wb_err))||(err_state))
 		o_wb_stb <= 1'b0;
@@ -146,27 +146,31 @@ module	axilwr2wbsp #(
 
 	// r_awvalid, r_addr
 	// {{{
-	initial	r_awvalid = 1'b0;
+	//initial	r_awvalid = 1'b0;
 	always @(posedge i_clk)
 	begin
-		if ((i_axi_awvalid)&&(o_axi_awready))
+
+		if (w_reset)
+			r_awvalid <= 1'b0;
+		else if ((i_axi_awvalid)&&(o_axi_awready))
 		begin
 			r_addr <= i_axi_awaddr;
 			r_awvalid <= (!axi_write_accepted);
 		end else if (axi_write_accepted)
 			r_awvalid <= 1'b0;
 
-		if (w_reset)
-			r_awvalid <= 1'b0;
 	end
 	// }}}
 
 	// r_wvalid
 	// {{{
-	initial	r_wvalid = 1'b0;
+	//initial	r_wvalid = 1'b0;
 	always @(posedge i_clk)
 	begin
-		if ((i_axi_wvalid)&&(o_axi_wready))
+
+		if (w_reset)
+			r_wvalid <= 1'b0;
+		else if ((i_axi_wvalid)&&(o_axi_wready))
 		begin
 			r_data <= i_axi_wdata;
 			r_sel  <= i_axi_wstrb;
@@ -174,14 +178,12 @@ module	axilwr2wbsp #(
 		end else if (axi_write_accepted)
 			r_wvalid <= 1'b0;
 
-		if (w_reset)
-			r_wvalid <= 1'b0;
 	end
 	// }}}
 
 	// o_axi_awready
 	// {{{
-	initial	o_axi_awready = 1'b1;
+	//initial	o_axi_awready = 1'b1;
 	always @(posedge i_clk)
 	if (w_reset)
 		o_axi_awready <= 1'b1;
@@ -209,7 +211,7 @@ module	axilwr2wbsp #(
 
 	// o_axi_wready
 	// {{{
-	initial	o_axi_wready = 1'b1;
+	//initial	o_axi_wready = 1'b1;
 	always @(posedge i_clk)
 	if (w_reset)
 		o_axi_wready <= 1'b1;
@@ -239,7 +241,7 @@ module	axilwr2wbsp #(
 
 	// wb_pending, wb_outstanding
 	// {{{
-	initial	wb_pending     = 0;
+	//initial	wb_pending     = 0;
 	always @(posedge i_clk)
 	if ((w_reset)||(!o_wb_cyc)||(i_wb_err)||(err_state))
 	begin
@@ -260,48 +262,53 @@ module	axilwr2wbsp #(
 
 	// o_axi_bresp
 	// {{{
-	initial	o_axi_bresp = 2'b00;
+	//initial	o_axi_bresp = 2'b00;
 	always @(posedge i_clk)
-	if (w_reset)
-		o_axi_bresp <= 0;
-	else if ((!o_axi_bvalid)||(i_axi_bready))
 	begin
-		if ((!err_state)&&((!o_wb_cyc)||(!i_wb_err)))
-			o_axi_bresp <= 2'b00;
-		else if ((!err_state)&&(o_wb_cyc)&&(i_wb_err))
-		begin
-			o_axi_bresp <= 2'b10;
-		end else if (err_state)
-		begin
-			o_axi_bresp <= 2'b10;
-		end else
-			o_axi_bresp <= 0;
+	  if (w_reset)
+		  o_axi_bresp <= 0;
+	  else if ((!o_axi_bvalid)||(i_axi_bready))
+	  begin
+		  if ((!err_state)&&((!o_wb_cyc)||(!i_wb_err)))
+			  o_axi_bresp <= 2'b00;
+		  else if ((!err_state)&&(o_wb_cyc)&&(i_wb_err))
+		  begin
+			  o_axi_bresp <= 2'b10;
+		  end else if (err_state)
+		  begin
+			  o_axi_bresp <= 2'b10;
+		  end else
+			  o_axi_bresp <= 0;
+	  end
 	end
 	// }}}
 
 	// err_state
 	// {{{
-	initial err_state  = 0;
+	//initial err_state  = 0;
 	always @(posedge i_clk)
-	if (w_reset)
-		err_state <= 0;
-	else if ((o_wb_cyc)&&(i_wb_err))
-		err_state <= 1'b1;
-	else err_state <= 0;	
-		
+	begin
+	  if (w_reset)
+		  err_state <= 0;
+	  else if ((o_wb_cyc)&&(i_wb_err))
+		  err_state <= 1'b1;
+	  else err_state <= 0;	
+	end
 	// }}}
 
 	// o_axi_bvalid
 	// {{{
-	initial	o_axi_bvalid = 1'b0;
+	//initial	o_axi_bvalid = 1'b0;
 	always @(posedge i_clk)
-	if (w_reset)
-		o_axi_bvalid <= 0;
-	else if ((o_wb_cyc)&&((i_wb_ack)||(i_wb_err)))
-		o_axi_bvalid <= 1'b1;
-	else if ((o_axi_bvalid)&&(i_axi_bready))
 	begin
-		o_axi_bvalid <= 1'b0;
+	  if (w_reset)
+		  o_axi_bvalid <= 0;
+	  else if ((o_wb_cyc)&&((i_wb_ack)||(i_wb_err)))
+		  o_axi_bvalid <= 1'b1;
+	  else if ((o_axi_bvalid)&&(i_axi_bready))
+	  begin
+		  o_axi_bvalid <= 1'b0;
+	  end
 	end
 	// }}}
 

--- a/axlite2wb/rtl/wbarbiter.sv
+++ b/axlite2wb/rtl/wbarbiter.sv
@@ -106,7 +106,7 @@ module	wbarbiter #(
 	reg	r_a_owner;
 
 	assign o_cyc = (r_a_owner) ? i_a_cyc : i_b_cyc;
-	initial	r_a_owner = 1'b1;
+	//initial	r_a_owner = 1'b1;
 
 	generate if (SCHEME == "PRIORITY")
 	begin : PRI
@@ -123,15 +123,19 @@ module	wbarbiter #(
 	begin : ALT
 
 		reg	last_owner;
-		initial	last_owner = 1'b0;
+		//initial	last_owner = 1'b0;
 		always @(posedge i_clk)
-			if ((i_a_cyc)&&(r_a_owner))
+			 if(i_reset)
+				last_owner <= 1'b0; 
+			 else if ((i_a_cyc)&&(r_a_owner))
 				last_owner <= 1'b1;
 			else if ((i_b_cyc)&&(!r_a_owner))
 				last_owner <= 1'b0;
 
 		always @(posedge i_clk)
-			if ((!i_a_cyc)&&(!i_b_cyc))
+			if(i_reset)
+				r_a_owner <= 1'b1;
+			else if ((!i_a_cyc)&&(!i_b_cyc))
 				r_a_owner <= !last_owner;
 			else if ((r_a_owner)&&(!i_a_cyc))
 			begin
@@ -150,7 +154,9 @@ module	wbarbiter #(
 	end else // if (SCHEME == "LAST")
 	begin : LST
 		always @(posedge i_clk)
-			if ((!i_a_cyc)&&(i_b_stb))
+			if(i_reset)
+				r_a_owner <= 1'b1;
+			else if ((!i_a_cyc)&&(i_b_stb))
 				r_a_owner <= 1'b0;
 			else if ((!i_b_cyc)&&(i_a_stb))
 				r_a_owner <= 1'b1;


### PR DESCRIPTION
Removed the initial assignments which were made for initializing the variables in simulation. These initial assignments were causing issues during the linting of the design.